### PR TITLE
Add at-rest encryption to the SNS topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | topic\_display\_name | The display name of the SNS topic. | `string` | `"cloudwatch_alarms"` | no |
+| topic\_kms\_encryption\_key\_id | The ID of the KMS key used to encrypt the SNS messages at rest.  By default the SNS service key is used. | `string` | `"alias/aws/sns"` | no |
 | topic\_name | The name of the SNS topic. | `string` | `"cloudwatch-alarms"` | no |
 
 ## Outputs ##

--- a/sns.tf
+++ b/sns.tf
@@ -4,8 +4,9 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_sns_topic" "cloudwatch_alarm" {
-  name         = var.topic_name
-  display_name = var.topic_display_name
+  name              = var.topic_name
+  display_name      = var.topic_display_name
+  kms_master_key_id = var.topic_kms_encryption_key_id
 }
 
 resource "aws_sns_topic_subscription" "account_email" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "topic_display_name" {
   default     = "cloudwatch_alarms"
 }
 
+variable "topic_kms_encryption_key_id" {
+  type        = string
+  description = "The ID of the KMS key used to encrypt the SNS messages at rest.  By default the SNS service key is used."
+  default     = "alias/aws/sns"
+}
+
 variable "topic_name" {
   type        = string
   description = "The name of the SNS topic."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds at-rest encryption to the SNS topic.  Note that we are using the service key.

## 💭 Motivation and context ##

We may as well.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.