### PR TITLE
Rename repo and generalize module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,22 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/cw-alarm-sns-tf-module/issues) in this
-repository.  We recommend that you first search through existing
-issues (both open and closed) to check if your particular issue has
-already been reported.  If it has then you might want to add a comment
-to the existing issue.  If it hasn't then feel free to create a new
-one.
+issue](https://github.com/cisagov/sns-send-to-account-email-tf-module/issues)
+in this repository.  We recommend that you first search through
+existing issues (both open and closed) to check if your particular
+issue has already been reported.  If it has then you might want to add
+a comment to the existing issue.  If it hasn't then feel free to
+create a new one.
 
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/cw-alarm-sns-tf-module/pulls), you
-will notice that our continuous integration (CI) system runs a fairly
-extensive set of linters and syntax checkers.  Your pull request may
-fail these checks, and that's OK.  If you want you can stop there and
-wait for us to make the necessary corrections to ensure your code
-passes the CI checks.
+request](https://github.com/cisagov/sns-send-to-account-email-tf-module/pulls),
+you will notice that our continuous integration (CI) system runs a
+fairly extensive set of linters and syntax checkers.  Your pull
+request may fail these checks, and that's OK.  If you want you can
+stop there and wait for us to make the necessary corrections to ensure
+your code passes the CI checks.
 
 If you want to make the changes yourself, or if you want to become a
 regular contributor, then you will want to set up
@@ -135,9 +135,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd cw-alarm-sns-tf-module
-pyenv virtualenv <python_version_to_use> cw-alarm-sns-tf-module
-pyenv local cw-alarm-sns-tf-module
+cd sns-send-to-account-email-tf-module
+pyenv virtualenv <python_version_to_use> sns-send-to-account-email-tf-module
+pyenv local sns-send-to-account-email-tf-module
 pip install --requirement requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# cw-alarm-sns-tf-module #
+# sns-send-to-account-email-tf-module #
 
-[![GitHub Build Status](https://github.com/cisagov/cw-alarm-sns-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/cw-alarm-sns-tf-module/actions)
+[![GitHub Build Status](https://github.com/cisagov/sns-send-to-account-email-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/sns-send-to-account-email-tf-module/actions)
 
 A Terraform module for:
 
 - Creating an SNS topic in an AWS account
 - Subscribing the email associated with the account to the new SNS
   topic
-
-The intent is to create an SNS topic to which messages will be sent
-when CloudWatch alarms trigger.
 
 ## Usage ##
 
@@ -19,7 +16,10 @@ module "example" {
     aws = aws
     aws.organizations_read_only = aws.organizations_read_only
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_display_name = "My SNS topic"
+  topic_name = "my_sns_topic"
 }
 ```
 
@@ -45,8 +45,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_sns_topic.cloudwatch_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
-| [aws_sns_topic_subscription.account_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
@@ -54,14 +54,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| topic\_display\_name | The display name of the SNS topic. | `string` | `"cloudwatch_alarms"` | no |
-| topic\_name | The name of the SNS topic. | `string` | `"cloudwatch-alarms"` | no |
+| topic\_display\_name | The display name of the SNS topic. | `string` | n/a | yes |
+| topic\_name | The name of the SNS topic. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
+| sns\_topic | The SNS topic to which a message can be sent to forward it on to the email associated with the account. |
 
 ## Notes ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "sns_topic" {
-  value       = aws_sns_topic.cloudwatch_alarm
-  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+  value       = aws_sns_topic.this
+  description = "The SNS topic to which a message can be sent to forward it on to the email associated with the account."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "sns_topic" {
-  value       = aws_sns_topic.this
   description = "The SNS topic to which a message can be sent to forward it on to the email associated with the account."
+  value       = aws_sns_topic.this
 }

--- a/sns.tf
+++ b/sns.tf
@@ -1,15 +1,16 @@
 # ------------------------------------------------------------------------------
-# Create the SNS topic that allows email to be sent for CloudWatch
-# alarms.  Subscribe the account email to the new SNS topic.
+# Create the SNS topic that allows email to be sent to the email
+# address associated with the account.  Subscribe the account email to
+# the new SNS topic.
 # ------------------------------------------------------------------------------
 
-resource "aws_sns_topic" "cloudwatch_alarm" {
+resource "aws_sns_topic" "this" {
   name         = var.topic_name
   display_name = var.topic_display_name
 }
 
-resource "aws_sns_topic_subscription" "account_email" {
+resource "aws_sns_topic_subscription" "this" {
   endpoint  = local.this_account_email
   protocol  = "email"
-  topic_arn = aws_sns_topic.cloudwatch_alarm.arn
+  topic_arn = aws_sns_topic.this.arn
 }

--- a/sns.tf
+++ b/sns.tf
@@ -9,8 +9,18 @@ resource "aws_sns_topic" "this" {
   display_name = var.topic_display_name
 }
 
+moved {
+  from = aws_sns_topic.cloudwatch_alarm
+  to   = aws_sns_topic.this
+}
+
 resource "aws_sns_topic_subscription" "this" {
   endpoint  = local.this_account_email
   protocol  = "email"
   topic_arn = aws_sns_topic.this.arn
+}
+
+moved {
+  from = aws_sns_topic_subscription.account_email
+  to   = aws_sns_topic_subscription.this
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 variable "topic_display_name" {
-  type        = string
   description = "The display name of the SNS topic."
+  type        = string
 }
 
 variable "topic_name" {
-  type        = string
   description = "The name of the SNS topic."
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,14 @@
 # ------------------------------------------------------------------------------
-# OPTIONAL PARAMETERS
+# REQUIRED PARAMETERS
 #
-# These parameters have reasonable defaults.
+# You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 variable "topic_display_name" {
   type        = string
   description = "The display name of the SNS topic."
-  default     = "cloudwatch_alarms"
 }
 
 variable "topic_name" {
   type        = string
   description = "The name of the SNS topic."
-  default     = "cloudwatch-alarms"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the documentation for the new repo name and generalizes the repo for uses other than just sending CloudWatch alarms to the email address associated with the account.

## 💭 Motivation and context ##

We want to use a similar setup to send messages to the email address associated with the account when IAM users are created; hence, it makes sense to generalize the repo a little bit to allow for this.

See also:
- cisagov/cool-accounts#137
- cisagov/cool-accounts-pca#32
- cisagov/cool-accounts-domain-manager#29

## 🧪 Testing ##

All automated tests pass.  I also successfully applied the the changes in this branch to [the `audit` subdirectory of cisagov/cool-accounts](https://github.com/cisagov/cool-accounts) in COOL production.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.