### PR TITLE
Add ability to specify an access policy for the SNS topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| topic\_access\_policy | The fully-formed JSOM IAM access policy to apply to the SNS topic. | `string` | `null` | no |
 | topic\_display\_name | The display name of the SNS topic. | `string` | n/a | yes |
 | topic\_name | The name of the SNS topic. | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| topic\_access\_policy | The fully-formed JSOM IAM access policy to apply to the SNS topic. | `string` | `null` | no |
+| topic\_access\_policy | The fully-formed JSON IAM access policy to apply to the SNS topic. | `string` | `null` | no |
 | topic\_display\_name | The display name of the SNS topic. | `string` | n/a | yes |
 | topic\_name | The name of the SNS topic. | `string` | n/a | yes |
 

--- a/sns.tf
+++ b/sns.tf
@@ -5,8 +5,9 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_sns_topic" "this" {
-  name         = var.topic_name
   display_name = var.topic_display_name
+  name         = var.topic_name
+  policy       = var.topic_access_policy
 }
 
 moved {

--- a/variables.tf
+++ b/variables.tf
@@ -22,4 +22,8 @@ variable "topic_access_policy" {
   default     = null
   description = "The fully-formed JSON IAM access policy to apply to the SNS topic."
   type        = string
+  validation {
+    condition     = can(jsondecode(var.topic_access_policy))
+    error_message = "The topic_access_policy value must be a string consisting of valid JSON."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,14 @@ variable "topic_name" {
   description = "The name of the SNS topic."
   type        = string
 }
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
+variable "topic_access_policy" {
+  default     = null
+  description = "The fully-formed JSOM IAM access policy to apply to the SNS topic."
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,6 @@ variable "topic_name" {
 # ------------------------------------------------------------------------------
 variable "topic_access_policy" {
   default     = null
-  description = "The fully-formed JSOM IAM access policy to apply to the SNS topic."
+  description = "The fully-formed JSON IAM access policy to apply to the SNS topic."
   type        = string
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the ability to specify an access policy for the SNS topic.

## 💭 Motivation and context ##

This is required for an EventBridge rule to be able to publish to the SNS topic, which is something we want to do in order to notify the proper folks when a new IAM or SSO user is created.

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to the `audit` subdirectory of [cisagov/cool-accounts](https://github.com/cisagov/cool-accounts) and verified that I was able to override the default access policy for the SNS topic.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Apply these changes to all COOL static accounts.
