### PR TITLE
Modify validation code to allow for a null value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "topic_access_policy" {
   description = "The fully-formed JSON IAM access policy to apply to the SNS topic."
   type        = string
   validation {
-    condition     = can(jsondecode(var.topic_access_policy))
-    error_message = "The topic_access_policy value must be a string consisting of valid JSON."
+    condition     = var.topic_access_policy == null || can(jsondecode(var.topic_access_policy))
+    error_message = "The topic_access_policy value must be null or a string consisting of valid JSON."
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the input variable validation code for `topic_access_policy` to allow for a `null` value.

## 💭 Motivation and context ##

A `null` value is a valid value for `topic_access_policy`; in fact, it is the default value for that variable.  The problem here is that I neglected to sufficiently retest the changes from commit 181658a of PR #24.  Mea culpa.

## 🧪 Testing ##

All automated tests pass.  I also verified that these changes do not cause issues when applied to to the `audit` subdirectory of [cisagov/cool-accounts](https://github.com/cisagov/cool-accounts).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.